### PR TITLE
Repair private Protocol checkout in CI

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+## Change
+
+Describe the bounded workbench, transport, editor, validation, or documentation change.
+
+## Validation impact
+
+- [ ] Packet Predator unit/foundation/browser tests updated or confirmed unaffected.
+- [ ] Protocol Contract conformance updated or confirmed unaffected.
+- [ ] Hardware Validation Console interface/scenario/verifier tests updated or confirmed unaffected.
+- [ ] Archived runtime hashes and quarantine boundaries remain intact.
+- [ ] Component and central documentation updated or confirmed unaffected.
+
+Explain every unchecked or unaffected layer:
+
+## Evidence
+
+List local commands and distinguish software tests from any physical result.

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -2,24 +2,49 @@ name: check
 
 on:
   push:
+    branches:
+      - main
   pull_request:
+  workflow_dispatch:
+    inputs:
+      protocol_ref:
+        description: Protocol Contract branch, tag, or commit
+        required: false
+        default: main
 
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
         with:
           path: Packet_Predator
           fetch-depth: 0
           fetch-tags: true
+          persist-credentials: false
+      - name: Require private sibling read token
+        env:
+          SIBLING_REPO_TOKEN: ${{ secrets.SIBLING_REPO_TOKEN }}
+        run: |
+          if [ -z "$SIBLING_REPO_TOKEN" ]; then
+            echo "::error::Configure the selected-repository SIBLING_REPO_TOKEN Actions secret with read-only Contents access."
+            exit 1
+          fi
       - uses: actions/checkout@v4
         with:
           repository: SuspiciousCellmates/Protocol_Contract
           path: Protocol_Contract
+          ref: ${{ inputs.protocol_ref || 'main' }}
+          token: ${{ secrets.SIBLING_REPO_TOKEN }}
+          persist-credentials: false
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,15 @@ current state without chat history or source-code archaeology.
   behavior, boundary, operation, or decision. Never claim hardware validation
   or support that has not actually occurred.
 
+## Validation impact
+
+Changes to the supported workbench require repository tests for the affected
+service, transport, editor, receiver, or browser boundary. If a published
+inspection/transmit interface used by Hardware Validation Console changes,
+update that Console's interface, scenario, failure, and evidence-verifier tests
+in the same coordinated work. Packet Predator must not absorb Scenario
+Simulator actors or Controller policy to make an integration test convenient.
+
 ## Completion
 
 Run `./scripts/check` before reporting completion. Preserve the archived-runtime hashes and do not add an architecture exception merely to make a check pass. ADR 0005 and `.foundation/runtime-baseline.json` authorize the nRF905 validation boundary; changing that boundary requires another ADR.


### PR DESCRIPTION
## What changed

- uses the read-only SIBLING_REPO_TOKEN for private Protocol Contract checkout
- avoids persisting checkout credentials
- adds default-branch and pull-request concurrency controls
- adds validation-impact contributor guidance

## Why

The repository-scoped GITHUB_TOKEN cannot clone a different private repository, so Actions stopped with a 404 before tests began.

## Validation

- ./scripts/check
- 88 tests passed
- workflow YAML parsed locally