### PR TITLE
Modernize workbench CI action runtimes

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           path: Packet_Predator
           fetch-depth: 0
@@ -38,14 +38,14 @@ jobs:
             echo "::error::Configure the selected-repository SIBLING_REPO_TOKEN Actions secret with read-only Contents access."
             exit 1
           fi
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           repository: SuspiciousCellmates/Protocol_Contract
           path: Protocol_Contract
           ref: ${{ inputs.protocol_ref || 'main' }}
           token: ${{ secrets.SIBLING_REPO_TOKEN }}
           persist-credentials: false
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
       - name: Install workbench dependencies


### PR DESCRIPTION
## Summary\n\n- update official GitHub Actions to the current Node 24-backed v7 majors\n- preserve existing workflow triggers, permissions, commands, inputs, and artifacts\n\n## Validation\n\n- repository completion check passed locally (Documentation remains intentionally provenance-pinned and is validated by this PR CI checkout)\n- workflow diff is limited to official action major versions